### PR TITLE
Se agregaron los campos de cabilderos al schema

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,6 +1,6 @@
 # Requerimientos de producto
 
-En este documento pretendemos definir los requerimientos de este producto, independientemente de los alcances. Este documento explicará el por qué de este producto, sómo de debe configurar su forma ideal y de pasada esperemos que sirva como template para más proyectos de la comunidad. Siéntete libre de retroalimentar su contenido y estructura.
+En este documento pretendemos definir los requerimientos de este producto, independientemente de los alcances. Este documento explicará el por qué de este producto, cómo se debe configurar su forma ideal y de pasada esperemos que sirva como template para más proyectos de la comunidad. Siéntete libre de retroalimentar su contenido y estructura.
 
 ## Sobre este producto
 

--- a/schema.md
+++ b/schema.md
@@ -79,7 +79,7 @@ Teléfono:
   * número
   * extensión
 
-Cabilderos personas morales del congreso de Guanajuato:
+Cabilderos:
   * rfc
   * razon_social
   * domicilio

--- a/schema.md
+++ b/schema.md
@@ -89,10 +89,13 @@ Cabilderos:
   * estatus_cabildero
   * anexo_buno (tratar como text)
   * anexo_bdos (tratar como text)
-  * no_acreditacion
+  * numero_acreditacion
   * persona_fisica
-  * no_cabildero
+  * numero_cabildero
   * fecha_acreditacion
   * organos_gobierno_comisiones
   * diputadas_diputados
   * diputados (arreglo con los datos de los diputados correspondientes)
+  * comisiones
+  * nombre
+  * colonia

--- a/schema.md
+++ b/schema.md
@@ -78,3 +78,21 @@ Sección:
 Teléfono:
   * número
   * extensión
+
+Cabilderos personas morales del congreso de Guanajuato:
+  * rfc
+  * razon_social
+  * domicilio
+  * telefono
+  * correo_electronico
+  * personas_autorizadas (tratar como array)
+  * estatus_cabildero
+  * anexo_buno (tratar como text)
+  * anexo_bdos (tratar como text)
+  * no_acreditacion
+  * persona_fisica
+  * no_cabildero
+  * fecha_acreditacion
+  * organos_gobierno_comisiones
+  * diputadas_diputados
+  * diputados (arreglo con los datos de los diputados correspondientes)


### PR DESCRIPTION
Se agregaron al ``schema.md`` nuevos campos correspondientes a la tabla de cabilderos de personas morales del congreso de Guanajuato, obtenidos del siguiente endpoint:

http://www.congresogto.gob.mx/cabildero_morales/personas_morales_api.json

**[Issue # 16](https://github.com/CodeandoMexico/representantes-patito-2/issues/16)**